### PR TITLE
Image

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -33,6 +33,7 @@ extensions = [
     'sphinx.ext.napoleon',
     'sphinx.ext.graphviz',
     'sphinxcontrib.spelling',
+    'sphinxcontrib.images',
     'notfound.extension',
     '_extentions.video',
     '_extentions.line_break',
@@ -46,6 +47,9 @@ spelling_exclude_patterns=['modules/dwn/*.rst']
 spelling_filters = ['_filters.Names']
 spelling_word_list_filename=[str(Path(__file__).expanduser().parent.joinpath('data', 'spelling', 'en_US.txt'))]
 spelling_verbose = False
+
+# image configuration 
+images_config = {"override_image_directive": True}
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -48,9 +48,6 @@ spelling_filters = ['_filters.Names']
 spelling_word_list_filename=[str(Path(__file__).expanduser().parent.joinpath('data', 'spelling', 'en_US.txt'))]
 spelling_verbose = False
 
-# image configuration 
-images_config = {"override_image_directive": True}
-
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
 

--- a/docs/source/setup/index.rst
+++ b/docs/source/setup/index.rst
@@ -9,8 +9,8 @@ If you don't find what you need please let us know using the `GitHub issue track
 
 We will be happy to receive contributions from people that use this documentation, so if you find a typo, don't hesitate to use the :code:`edit this page` button on the right side of every documentation page to help us improve the way we present the platform!
 
-.. figure:: ../img/setup/index/planet_classification.png
-    :alt: Uganda planet classifications
+.. thumbnail:: ../img/setup/index/planet_classification.png
+    :title: Uganda planet classifications
 
     example of a classification for Uganda based on a combination of Sentinel-1 Timescan and Sentinel-2 CCDC slice data using the classification tool in SEPAL
 

--- a/docs/source/setup/index.rst
+++ b/docs/source/setup/index.rst
@@ -10,7 +10,6 @@ If you don't find what you need please let us know using the `GitHub issue track
 We will be happy to receive contributions from people that use this documentation, so if you find a typo, don't hesitate to use the :code:`edit this page` button on the right side of every documentation page to help us improve the way we present the platform!
 
 .. thumbnail:: ../img/setup/index/planet_classification.png
-    :alt: Uganda planet classifications
 
     example of a classification for Uganda based on a combination of Sentinel-1 Timescan and Sentinel-2 CCDC slice data using the classification tool in SEPAL
 

--- a/docs/source/setup/index.rst
+++ b/docs/source/setup/index.rst
@@ -10,7 +10,7 @@ If you don't find what you need please let us know using the `GitHub issue track
 We will be happy to receive contributions from people that use this documentation, so if you find a typo, don't hesitate to use the :code:`edit this page` button on the right side of every documentation page to help us improve the way we present the platform!
 
 .. thumbnail:: ../img/setup/index/planet_classification.png
-    :title: Uganda planet classifications
+    :alt: Uganda planet classifications
 
     example of a classification for Uganda based on a combination of Sentinel-1 Timescan and Sentinel-2 CCDC slice data using the classification tool in SEPAL
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ Sphinx>=3.5.1
 sphinx-notfound-page>=0.6
 graphviz>=0.16
 sphinxcontrib-spelling
+sphinxcontrib-images


### PR DESCRIPTION
use thumbnails in the documentation 

If the images are too small they can now be displayed using thumbnails. Please follow the documentation to use the directive: https://sphinxcontrib-images.readthedocs.io/en/latest/