### PR TITLE
create a btn role

### DIFF
--- a/docs/source/_extentions/btn.py
+++ b/docs/source/_extentions/btn.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+
+from docutils import nodes
+
+def btn_role(name, rawtext, text, lineno, inliner, options={}, content=[]):
+    """add inline btn
+
+    Returns 2 part tuple containing list of nodes to insert into the
+    document and a list of system messages.  Both are allowed to be
+    empty.
+
+    :param name: The role name used in the document.
+    :param rawtext: The entire markup snippet, with role.
+    :param text: The text marked with the role. (it should use the following format: `<fontawesome icon> text`) color is optional
+    :param lineno: The line number where rawtext appears in the input.
+    :param inliner: The inliner instance that called us.
+    :param options: Directive options for customization.
+    :param content: The directive content for customization.
+    """
+    node =nodes.reference()
+    
+    # get the icon parameters
+    if text.find("<") != -1:
+        start = text.find("<")
+        end = text.find(">")
+        icon = text[start+1:end]
+        text = text[end+1:]
+    else:
+        icon = ""
+    
+    margin = 'mr-1' if text else ''
+    html = f'<span class="guilabel"><i class="{icon} {margin}"></i>{text.strip()}</span>'
+    
+    node = nodes.raw('', html, format='html')
+    return [node], []
+
+def setup(app):
+    """Install the plugin.
+
+    :param app: Sphinx application context.
+    """
+    app.add_role('btn', btn_role)
+    return

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -39,6 +39,7 @@ extensions = [
     '_extentions.line_break',
     '_extentions.custom_edit',
     '_extentions.icon',
+    '_extentions.btn'
 ]
 
 # spelling options

--- a/docs/source/team/contribute.rst
+++ b/docs/source/team/contribute.rst
@@ -117,6 +117,21 @@ ReST role to include inline icons in the documenation (usualy when referencing a
 
 I'm a folder icon: :icon:`fa fa-folder`
 
+btn
+"""
+
+Rest role to include complete btn in the documentation. You can find the icon you're looking for in the fontawesome library `page <https://fontawesome.com/v5.15/icons?d=gallery&p=2>`__. The text is optional.
+
+.. code-block:: rst 
+
+    I'm a apply btn: :btn:`<fas fa-check> apply`
+
+    I'm the app btn: :btn:`<fas fa-wrench>`
+
+I'm a apply btn: :btn:`<fas fa-check> apply`
+
+I'm the app btn: :btn:`<fas fa-wrench>`
+
 Minor change
 ------------
 


### PR DESCRIPTION
Fix #108 

create a btn role to create btns that embeds both the icon and text: 
![Capture d’écran 2021-12-13 à 13 52 43](https://user-images.githubusercontent.com/12596392/145815894-3409b6fe-6520-4a96-a28e-10e5be1794c1.png)

