### PR TITLE
install graphviz lib in rdt configuration

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,6 +7,8 @@ version: 2
 # build with latest available ubuntu version
 build:
   os: ubuntu-20.04
+  apt_packages:
+    - graphviz
   tools:
     python: "3.9"
 


### PR DESCRIPTION
Fix #155 

Graphviz is not installed in the RDT build automatically as it was before.