### PR TITLE
doc: update create venv instructions.

### DIFF
--- a/docs/source/cli/python.rst
+++ b/docs/source/cli/python.rst
@@ -56,28 +56,26 @@ SEPAL supports python venv creation. in this section we'll explain how you can c
 
 By design Jupyter is runnnig on the Python Kernel described in the previous section. you can also use the kernel associated to our applications (they start with :code:`venv`). If your work rely on very specific version numbers it might be good to run everything on a dedicated environment.
 
-If not existing, create a directory to host your virtual environments. From the root directory run:
+If not existing, create a directory to host your virtual environments. From the root directory, run the following line:
 
-.. code-block:: console
+.. code-block:: bash
 
-    mkdir venv
+    folder_name="my_virtual_env"  # Replace my_virtual_env with the name you want to give to the folder that will hold your virtual environment
 
-in this folder create a virtual environment:
+And then, copy and paste the following lines in your terminal:
 
-.. code-block:: console
+.. code-block:: bash
 
-    cd venv
-    python3 -m venv <venv_name>
-
-Now create a Jupyter Kernel linked to this venv:
-
-.. code-block:: console
-
-    ./<venv_name>/python3 -m ipykernel install --user --name <venv_name> --display-name <a name to display>
+    mkdir -p "$folder_name" # Create your folder (included partents if are given).
+    python3 -m venv "$folder_name" # Create the venv, this line could take some time.
+    source "$folder_name/bin/activate" # Activate the virtual enviroment just created.
+    pip install ipykernel # Install ipykernel in our venv.
+    python -m ipykernel install --user --name="$folder_name" -display-name="(venv) - $folder_name" # Add the new venv kernel to jupyter.
+    deactivate # (optional) exit from environment.
 
 Now this venv will be available as a kernel inside your Jupyter workspace. This kernel will be automatically removed if you destroy the venv directory.
 
-If you want to install libs inside this venv you need first to activate it:
+Note that If you want to install libs inside this venv you need first to activate it:
 
 .. code-block:: console
 

--- a/docs/source/cli/python.rst
+++ b/docs/source/cli/python.rst
@@ -79,5 +79,5 @@ Note that If you want to install libs inside this venv you need first to activat
 
 .. code-block:: console
 
-    source ./<venv_name>/bin/activate
+    source your_venv_path/bin/activate
 


### PR DESCRIPTION
It was failing because there was no installation of `ipykernel` before, now it'll simple, the user will only have to assign a value to the `$folder_name` variable:


https://sepal-doc--285.org.readthedocs.build/en/285/cli/python.html#virtual-environment