### PR TITLE
fix: edit cron job to avoid failure

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,3 +33,10 @@ jobs:
           branch: l18n_main_cron
           create_branch: true
           commit_message: Automatic compilation update
+
+      - name: Run the Action
+        uses: devops-infra/action-pull-request@v0.5.5
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          source_branch: l18_main_branch
+          target_branch: main

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,6 +30,6 @@ jobs:
       - name: push the files
         uses: stefanzweifel/git-auto-commit-action@v4
         with:
-          branch: l18n_main
+          branch: l18n_main_cron
           create_branch: true
           commit_message: Automatic compilation update

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,6 +33,7 @@ jobs:
           branch: l18n_main_cron
           create_branch: true
           commit_message: Automatic compilation update
+          push_options: "--force"
 
       - name: Run the Action
         uses: devops-infra/action-pull-request@v0.5.5


### PR DESCRIPTION
Related to #386 

- the branch of crowdin an cron job were conflicting. I changed the one from the cron job to `l18n_main_cron`
- I changed the repository settings to automatically delete branches  when PR are merged to avoid stale branches 
- use the `--force` option to make sure the push always work evehn whgen the target branch already exist
- create a PR automatically to check the RDT build before merging