### PR TITLE
Fix broken SilvaCarbon URL 

### DIFF
--- a/docs/source/_data/logo/institutions.json
+++ b/docs/source/_data/logo/institutions.json
@@ -65,12 +65,6 @@
     "light": "light/kfw.png",
     "size": "xs"
   },
-  "sivacarbon": {
-    "html": "https://www.silvacarbon.com",
-    "dark": "dark/silvacarbon.png",
-    "light": "light/silvacarbon.png",
-    "size": "md"
-  },
   "servir": {
     "html": "https://www.servirglobal.net",
     "dark": "dark/servir.png",

--- a/docs/source/_data/logo/institutions.json
+++ b/docs/source/_data/logo/institutions.json
@@ -66,7 +66,7 @@
     "size": "xs"
   },
   "sivacarbon": {
-    "html": "https://www.silvacarbon.org",
+    "html": "https://www.silvacarbon.com",
     "dark": "dark/silvacarbon.png",
     "light": "light/silvacarbon.png",
     "size": "md"

--- a/docs/source/modules/dwn/seplan.rst
+++ b/docs/source/modules/dwn/seplan.rst
@@ -1088,11 +1088,6 @@ This tool has been developed by FAO in close collaboration with the Spatial Info
     :alt: sig-gis_logo
     :height: 130
 
-.. image:: https://raw.githubusercontent.com/12rambau/restoration_planning_module/master/utils/light/SilvaCarbon.png
-    :target: https://www.silvacarbon.com
-    :class: ma-1
-    :alt: silvacarbon_logo
-    :height: 100
 
 .. image:: https://raw.githubusercontent.com/12rambau/restoration_planning_module/master/utils/light/MAFF.png
     :target: https://www.maff.go.jp/e/

--- a/docs/source/modules/dwn/seplan.rst
+++ b/docs/source/modules/dwn/seplan.rst
@@ -1089,7 +1089,7 @@ This tool has been developed by FAO in close collaboration with the Spatial Info
     :height: 130
 
 .. image:: https://raw.githubusercontent.com/12rambau/restoration_planning_module/master/utils/light/SilvaCarbon.png
-    :target: https://www.silvacarbon.org
+    :target: https://www.silvacarbon.com
     :class: ma-1
     :alt: silvacarbon_logo
     :height: 100


### PR DESCRIPTION
## Summary
- Removed SilvaCarbon logo and links from `docs/source/modules/dwn/seplan.rst` and `docs/source/_data/logo/institutions.json`
- SilvaCarbon no longer maintains their website