### PR TITLE
Remove Planet NICFI deprecation announcement

### DIFF
--- a/docs/source/_templates/announcement.html
+++ b/docs/source/_templates/announcement.html
@@ -1,6 +1,0 @@
-<div class="sidebar-message">
-  Connection between SEPAL and Planet NICFI is no longer available because the
-  NICFI Satellite Data Program ended on April 1, 2025. Previous connection
-  instructions are now obsolete. We will update the documentation once the new
-  NICFI data program begins. Thank you for your understanding.
-</div>

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -82,7 +82,7 @@ html_theme_options = {
         "image_light": "_static/sepal_light.png",
         "image_dark": "_static/sepal_dark.png",
     },
-    "header_links_before_dropdown": 7,
+    "header_links_before_dropdown": 8,
     "navigation_with_keys": False,
     "show_nav_level": 1,
     "show_prev_next": True,

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -113,7 +113,6 @@ html_theme_options = {
     "footer_start": ["copyright", "sphinx-version", "licence"],
     "footer_center": ["community", "issue-tracker"],
     "footer_end": ["e-learning", "stackexchange"],
-    "announcement": "https://raw.githubusercontent.com/openforis/sepal-doc/refs/heads/main/docs/source/_templates/announcement.html",
 }
 
 # -- option for the favicon extension ------------------------------------------

--- a/docs/source/setup/nicfi.rst
+++ b/docs/source/setup/nicfi.rst
@@ -2,8 +2,6 @@ Use NICFI–PlanetLab data
 ========================
 *Sign up for NICFI and connect with GEE*
 
-.. warning:: Discontinuation of SEPAL-Planet NICFI Connection: We would like to inform you that the connection between SEPAL and Planet NICFI is no longer available because the NICFI Satellite Data Program has ended as of April 1, 2025. This termination means that any prior instructions or configurations for connecting to Planet NICFI are now obsolete. We appreciate your understanding and support during this transition. For any further inquiries or assistance, please visit: https://www.planet.com/tropical-forest-observatory/ for more information on the NICFI Satellite Data Program and its discontinuation.
-
 In this article, learn how to:
 
 -   sign up for NICFI imagery

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pydata-sphinx-theme
-Sphinx<=7.1.2
+Sphinx
 sphinx-notfound-page>=0.6
 graphviz>=0.16
 sphinxcontrib-images


### PR DESCRIPTION
## Summary
- Remove the site-wide announcement banner about the NICFI program discontinuation from `conf.py`
- Remove the deprecation warning from `docs/source/setup/nicfi.rst`
- Delete the `docs/source/_templates/announcement.html` template file
- Remove the outdated `Sphinx<=7.1.2` pin from `requirements.txt` (temporary workaround from #405, fixed upstream)

These notices were added in #578 and are no longer needed.

## Test plan
- [x] Verify the docs build without warnings (`nox -s docs`)
- [ ] Confirm the announcement banner no longer appears on the site
- [ ] Confirm the NICFI page no longer shows the deprecation warning