### PR TITLE
Prevent navbar items from wrapping

### DIFF
--- a/docs/source/_static/css/custom.css
+++ b/docs/source/_static/css/custom.css
@@ -23,6 +23,14 @@
 }
 
 /*******************************************************************************
+*   prevent navbar items from wrapping
+*
+**/
+.pst-header-nav-item > .nav-link {
+  white-space: nowrap;
+}
+
+/*******************************************************************************
 *   prevent pydata from adding extra background colors to my images
 *   to be removed when https://github.com/pydata/pydata-sphinx-theme/issues/879
 *   will be solved


### PR DESCRIPTION
## Summary
- Add `white-space: nowrap` to `.pst-header-nav-item > .nav-link` so long labels like "Getting started" don't break onto a second line in the navigation bar

## Test plan
- [x] Local build passes (`nox -s docs`)
- [ ] Verify navbar renders on a single line at various viewport widths