### PR TITLE
Bump scheduled build workflow to Python 3.10

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,10 +13,10 @@ jobs:
         with:
           ref: ${{ github.head_ref }}
 
-      - name: Set up Python 3.8
+      - name: Set up Python 3.10
         uses: actions/setup-python@v4
         with:
-          python-version: "3.8"
+          python-version: "3.10"
 
       - name: Install dependencies
         run: python -m pip install nox


### PR DESCRIPTION
## Summary
- Update `.github/workflows/build.yml` from Python 3.8 to 3.10
- Python 3.8 can no longer resolve the unpinned Sphinx dependency — newer Sphinx requires Python >=3.10
- Aligns with the Python version already used in `unit.yml`

Fixes the scheduled `nox -s compile` failure (`ResolutionTooDeep`) introduced after removing the `Sphinx<=7.1.2` pin in #585.

## Test plan
- [x] Local build passes (`nox -s docs`)
- [ ] Scheduled build workflow passes with Python 3.10