### PR TITLE
Refactor build workflow — trigger on push instead of daily cron

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,42 +2,52 @@ name: Build
 
 on:
   workflow_dispatch:
-  schedule:
-    - cron: "0 0 * * *"
+  push:
+    branches:
+      - main
 
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-        with:
-          ref: ${{ github.head_ref }}
+      - uses: actions/checkout@v4
 
       - name: Set up Python 3.10
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.10"
 
       - name: Install dependencies
         run: python -m pip install nox
 
-      - name: update module files
+      - name: Update module files
         run: nox -s compile
 
-      - name: generate .po files
+      - name: Generate .po files
         run: nox -s i18n
 
-      - name: push the files
-        uses: stefanzweifel/git-auto-commit-action@v4
+      - name: Check for changes
+        id: changes
+        run: |
+          if git diff --quiet; then
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Push changes
+        if: steps.changes.outputs.has_changes == 'true'
+        uses: stefanzweifel/git-auto-commit-action@v5
         with:
           branch: l18n_main_cron
           create_branch: true
-          commit_message: Automatic compilation update
+          commit_message: "Automatic compilation and i18n update"
           push_options: "--force"
 
-      - name: Run the Action
+      - name: Create pull request
+        if: steps.changes.outputs.has_changes == 'true'
         uses: devops-infra/action-pull-request@v0.5.5
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          source_branch: l18_main_branch
+          source_branch: l18n_main_cron
           target_branch: main

--- a/.gitignore
+++ b/.gitignore
@@ -138,3 +138,6 @@ dmypy.json
 
 # mac os files
 .DS_Store
+
+# Claude Code
+CLAUDE.md


### PR DESCRIPTION
## Summary
- Replace daily cron schedule with push-to-main trigger — no more wasted builds when nothing changed
- Add change detection step — skip commit/push/PR when `compile` and `i18n` produce no changes
- Fix branch name mismatch — PR step referenced `l18_main_branch` but commits went to `l18n_main_cron`
- Bump GitHub Actions to latest versions (checkout v4, setup-python v5, git-auto-commit v5)
- Keep `workflow_dispatch` for manual runs
- Add `CLAUDE.md` to `.gitignore`

## Test plan
- [x] Local build passes (`nox -s docs`)
- [ ] Workflow triggers on push to main
- [ ] Workflow skips commit/push when there are no changes
- [ ] Workflow creates PR when there are actual changes