### PR TITLE
Add "For developers" section covering the SEPAL apps catalog

### DIFF
--- a/docs/source/developers/apps/app_catalog.rst
+++ b/docs/source/developers/apps/app_catalog.rst
@@ -1,0 +1,273 @@
+.. _developers_apps_catalog:
+
+Request a new app
+=================
+*Add your app to the SEPAL apps catalog so it appears on the platform*
+
+The catalog
+-----------
+
+The list of apps SEPAL runs lives in a dedicated repository,
+`dfguerrerom/sepal-apps-catalog <https://github.com/dfguerrerom/sepal-apps-catalog>`__.
+For docker apps the catalog pins the exact commit SEPAL will run; for jupyter
+and shiny apps it records the ``branch`` and SEPAL runs its tip. Either way,
+adding or updating an app means opening a pull request against this catalog,
+where a maintainer reviews the change before it goes live.
+
+The catalog ships two files:
+
+-   ``apps.test.json`` — apps available on test.sepal.io (the staging
+    environment used to validate changes before they reach end users)
+-   ``apps.prod.json`` — apps available on sepal.io (the production environment)
+
+New apps always land in ``apps.test.json`` first and are promoted to
+``apps.prod.json`` only once they behave correctly on test.sepal.io.
+
+Anatomy of a catalog entry
+--------------------------
+
+An app is a JSON object in the ``apps`` array. The schema only enforces ``id``
+and ``label`` as universally required, plus a docker-specific block — but the
+catalog convention is to **fill every field** so each entry carries a complete
+dashboard listing. The only practical exceptions:
+
+-   ``port`` applies only to docker apps (and is required there).
+-   For hidden kernel-only apps (see :ref:`developers_apps_kernels`) the
+    user-facing presentation fields (``description``, ``tagline``,
+    ``logoRef``, ``projectLink``, ``author``, ``tags``) can be omitted, since
+    they are never shown.
+
+Identification and routing
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. list-table::
+    :header-rows: 1
+    :widths: 22 22 56
+
+    * - Field
+      - When
+      - Meaning
+    * - ``id``
+      - always (schema)
+      - Unique identifier across the catalog (``[A-Za-z0-9_.-]+``).
+    * - ``label``
+      - always (schema)
+      - Display name shown on the apps dashboard.
+    * - ``endpoint``
+      - always
+      - How SEPAL runs the app: ``jupyter``, ``shiny``, ``rstudio`` or
+        ``docker``. See :ref:`developers_apps_types`.
+    * - ``repository``
+      - always
+      - ``https://github.com/<owner>/<repo>`` of the app source. SEPAL clones
+        it to run the app.
+    * - ``branch``
+      - always
+      - Branch the app tracks (commonly ``release``).
+    * - ``path``
+      - always
+      - Entry point the app-launcher routes to. For jupyter, the Voila URL of
+        the notebook (e.g.
+        ``/sandbox/jupyter/voila/render/shared/apps/<app>/ui.ipynb``); for
+        shiny, the sandbox path of the Shiny project; for docker, **must
+        match** ``/api/app-launcher/<id>`` (schema-enforced).
+
+Docker-only fields
+~~~~~~~~~~~~~~~~~~~
+
+.. list-table::
+    :header-rows: 1
+    :widths: 22 22 56
+
+    * - Field
+      - When
+      - Meaning
+    * - ``commit``
+      - docker only (schema)
+      - Full 40-character lowercase commit SHA. Required for
+        ``endpoint: docker``; not allowed for other endpoints, which track the
+        branch tip.
+    * - ``port``
+      - docker only (schema)
+      - Container port the docker app listens on. Integer 1–65535. Must be
+        unique across the catalog — see
+        `dfguerrerom/sepal-apps-catalog#41 <https://github.com/dfguerrerom/sepal-apps-catalog/issues/41>`__.
+
+Presentation
+~~~~~~~~~~~~~
+
+These fields populate the dashboard tile and the app's detail page. Skip them
+*only* on hidden kernel-only entries.
+
+.. list-table::
+    :header-rows: 1
+    :widths: 22 22 56
+
+    * - Field
+      - When
+      - Meaning
+    * - ``author``
+      - visible apps
+      - Who maintains the app (free-form string).
+    * - ``description``
+      - visible apps
+      - Long-form description shown on the app's detail page.
+    * - ``tagline``
+      - visible apps
+      - One-line summary shown on the dashboard tile.
+    * - ``logoRef``
+      - visible apps
+      - Filename of the logo asset bundled with the catalog (e.g.
+        ``my-app.svg``).
+    * - ``projectLink``
+      - visible apps
+      - URL to the project's home page, docs, or upstream repository.
+    * - ``tags``
+      - visible apps
+      - Array of tag values defined in the catalog's top-level ``tags`` block
+        (e.g. ``["TOOLS", "TIME_SERIES"]``).
+
+Behaviour flags
+~~~~~~~~~~~~~~~~
+
+Optional booleans that alter how the app is listed or launched. Defaults are
+all ``false``.
+
+.. list-table::
+    :header-rows: 1
+    :widths: 22 22 56
+
+    * - Field
+      - When
+      - Meaning
+    * - ``hidden``
+      - optional
+      - If ``true``, the app builds but does not show a dashboard tile. Used
+        for packaged kernels — see :ref:`developers_apps_kernels`.
+    * - ``pinned``
+      - optional
+      - Pin the app to the top of the dashboard.
+    * - ``googleAccountRequired``
+      - optional
+      - The app needs a connected Google account (e.g. for GEE).
+    * - ``single``
+      - optional
+      - Only one instance of this app can run at a time per user (used by the
+        built-in ``jupyter-notebook``, ``jupyter-lab`` and ``rstudio`` tools).
+    * - ``skip``
+      - optional
+      - Temporarily skip building/serving this app without removing the entry.
+
+A typical jupyter entry — every field a user sees on the dashboard is filled
+in:
+
+.. code-block:: json
+
+    {
+      "id": "my-app",
+      "label": "My App",
+      "endpoint": "jupyter",
+      "repository": "https://github.com/me/my-sepal-app",
+      "branch": "release",
+      "path": "/sandbox/jupyter/voila/render/shared/apps/my-app/ui.ipynb",
+      "author": "Me and contributors",
+      "tagline": "Short one-line summary shown on the dashboard tile.",
+      "description": "Longer description shown on the app's detail page.",
+      "logoRef": "my-app.svg",
+      "projectLink": "https://github.com/me/my-sepal-app",
+      "tags": [
+        "TIME_SERIES"
+      ]
+    }
+
+A docker entry adds the docker-only ``commit``, ``port`` and the
+schema-enforced ``/api/app-launcher/<id>`` path; the presentation fields are
+the same:
+
+.. code-block:: json
+
+    {
+      "id": "my-docker-app",
+      "label": "My Docker App",
+      "endpoint": "docker",
+      "repository": "https://github.com/me/my-sepal-docker-app",
+      "branch": "main",
+      "commit": "0123456789abcdef0123456789abcdef01234567",
+      "port": 8767,
+      "path": "/api/app-launcher/my-docker-app",
+      "author": "Me and contributors",
+      "tagline": "Short one-line summary shown on the dashboard tile.",
+      "description": "Longer description shown on the app's detail page.",
+      "logoRef": "my-docker-app.svg",
+      "projectLink": "https://github.com/me/my-sepal-docker-app",
+      "tags": [
+        "TOOLS"
+      ]
+    }
+
+Adding the app
+--------------
+
+#.  Open a pull request adding your entry to ``apps.test.json``. The fastest
+    way is to edit the file directly on GitHub:
+    `edit apps.test.json <https://github.com/dfguerrerom/sepal-apps-catalog/edit/main/apps.test.json>`__.
+    For a docker app, ``commit`` must be a full 40-character SHA that exists
+    on the declared ``branch``.
+#.  The ``Validate catalog`` and ``Review helper`` workflows run automatically.
+    Validation is a blocking gate (schema, canonical formatting, and — for
+    docker apps — a check that the commit is reachable from its branch). The
+    review helper posts a single PR comment with a per-app diff and *risk
+    flags* (new dependencies, network calls, shell-outs) to help maintainers
+    review safely.
+#.  A SEPAL maintainer reviews and merges. Once merged, the app appears on
+    test.sepal.io within minutes.
+#.  When you are happy with its behaviour on test.sepal.io, promote it to
+    production — see `Promoting to production`_.
+
+Promoting to production
+-----------------------
+
+Promotion copies the *exact same pinned reference* (commit for docker, branch
+for the others) from ``apps.test.json`` into ``apps.prod.json``. There are two
+mechanical ways to do it:
+
+-   Open a follow-up PR copying the entry into ``apps.prod.json``, or
+-   Trigger the ``Promote app to production`` workflow
+    (``workflow_dispatch``, pick an app), which opens that PR for you.
+
+Either way the same validation and review checks run, a maintainer merges, and
+the app goes live on sepal.io.
+
+.. note::
+
+    **Promotion is currently restricted to the catalog owner.** The
+    ``workflow_dispatch`` trigger and the merge step both require write access
+    to the catalog repository, so contributors cannot promote their own apps
+    today — they have to ask the catalog owner to do it. Tracked in
+    `dfguerrerom/sepal-apps-catalog#40 <https://github.com/dfguerrerom/sepal-apps-catalog/issues/40>`__.
+
+Working on the catalog locally
+------------------------------
+
+The catalog files use canonical ``JSON.stringify(parsed, null, 2)`` formatting
+(2-space indent, one-element arrays expanded, trailing newline). A
+``.prettierignore`` keeps editor formatters off them, and CI rejects PRs that
+don't match. Install the pre-commit hooks once so problems are caught before
+they fail CI:
+
+.. code-block:: bash
+
+    pip install pre-commit              # or: pipx install pre-commit
+    pre-commit install
+    npm install --prefix .github/workflows/scripts
+
+To re-canonicalize a file before pushing:
+
+.. code-block:: bash
+
+    node -e 'const fs=require("fs"); for (const f of ["apps.test.json","apps.prod.json"]) fs.writeFileSync(f, JSON.stringify(JSON.parse(fs.readFileSync(f,"utf8")),null,2)+"\n")'
+
+.. seealso::
+
+    The catalog's own ``docs/contributing.md`` and ``docs/ci.md`` document
+    every workflow, check, and script in detail.

--- a/docs/source/developers/apps/app_catalog.rst
+++ b/docs/source/developers/apps/app_catalog.rst
@@ -70,7 +70,9 @@ Identification and routing
         the notebook (e.g.
         ``/sandbox/jupyter/voila/render/shared/apps/<app>/ui.ipynb``); for
         shiny, the sandbox path of the Shiny project; for docker, **must
-        match** ``/api/app-launcher/<id>`` (schema-enforced).
+        equal** ``/api/app-launcher/<id>`` exactly — the schema enforces the
+        prefix and ``check-docker-rules.js`` enforces that ``<id>`` matches
+        the entry's ``id``.
 
 Docker-only fields
 ~~~~~~~~~~~~~~~~~~~
@@ -90,8 +92,10 @@ Docker-only fields
     * - ``port``
       - docker only (schema)
       - Container port the docker app listens on. Integer 1–65535. Must be
-        unique across the catalog — see
-        `dfguerrerom/sepal-apps-catalog#41 <https://github.com/dfguerrerom/sepal-apps-catalog/issues/41>`__.
+        unique across ``apps.test.json`` and ``apps.prod.json``;
+        ``check-docker-rules.js`` enforces this and prints
+        ``Next free port: N`` on a violation. New apps take the next free
+        port — ``max(existing_ports) + 1``.
 
 Presentation
 ~~~~~~~~~~~~~
@@ -228,23 +232,39 @@ Promoting to production
 -----------------------
 
 Promotion copies the *exact same pinned reference* (commit for docker, branch
-for the others) from ``apps.test.json`` into ``apps.prod.json``. There are two
-mechanical ways to do it:
+for the others) from ``apps.test.json`` into ``apps.prod.json``. Two paths,
+either of which produces the same promotion PR for a maintainer to merge:
 
--   Open a follow-up PR copying the entry into ``apps.prod.json``, or
--   Trigger the ``Promote app to production`` workflow
-    (``workflow_dispatch``, pick an app), which opens that PR for you.
+Self-service ``/promote`` comment (recommended)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Either way the same validation and review checks run, a maintainer merges, and
-the app goes live on sepal.io.
+The catalog has a single pinned issue titled *"Promotion requests — comment
+``/promote <app-id>`` here"*, labeled ``promote-request``. Find it in the
+catalog's `issues tab
+<https://github.com/dfguerrerom/sepal-apps-catalog/issues?q=is%3Aissue+is%3Aopen+label%3Apromote-request>`__
+(there is only ever one) and comment:
 
-.. note::
+.. code-block:: text
 
-    **Promotion is currently restricted to the catalog owner.** The
-    ``workflow_dispatch`` trigger and the merge step both require write access
-    to the catalog repository, so contributors cannot promote their own apps
-    today — they have to ask the catalog owner to do it. Tracked in
-    `dfguerrerom/sepal-apps-catalog#40 <https://github.com/dfguerrerom/sepal-apps-catalog/issues/40>`__.
+    /promote my-app-id
+
+The ``Promote app on /promote comment`` workflow then verifies the commenter is
+authorized for the app's source repository and, if so, opens the promotion PR.
+Authorization uses public GitHub data only:
+
+-   If the source repo is owned by a User, the commenter must equal that user.
+-   If it is owned by an Organization, the commenter must be a **public**
+    member of that org. If your membership is private, make it public at
+    ``https://github.com/orgs/<org>/people`` or use the manual-PR path below.
+
+A maintainer still merges the PR.
+
+Manual PR
+~~~~~~~~~
+
+Open a pull request copying the entry's ``commit`` (or whole object) from
+``apps.test.json`` into ``apps.prod.json``. The same validation and review
+checks run; a maintainer merges.
 
 Working on the catalog locally
 ------------------------------

--- a/docs/source/developers/apps/app_types.rst
+++ b/docs/source/developers/apps/app_types.rst
@@ -1,0 +1,95 @@
+.. _developers_apps_types:
+
+Docker vs. Jupyter apps
+=======================
+*Two ways an app runs on SEPAL, with different lifecycles*
+
+Every catalog entry declares an ``endpoint`` that tells SEPAL how to run the
+app. The two you will meet most often are ``docker`` and ``jupyter`` (``shiny``
+and ``rstudio`` behave like ``jupyter`` for lifecycle purposes). The choice
+affects how the app is isolated, how it is versioned, and how it is updated.
+
+At a glance
+-----------
+
+.. list-table::
+    :header-rows: 1
+    :widths: 28 36 36
+
+    * -
+      - Docker app
+      - Jupyter app
+    * - ``endpoint``
+      - ``docker``
+      - ``jupyter`` (also ``shiny``, ``rstudio``)
+    * - Runs in
+      - Its own container, on its own port
+      - The shared user sandbox, served through Voila
+    * - Versioning
+      - Pinned to a commit SHA (required)
+      - Tracks its branch; no commit pin
+    * - Code location
+      - Cloned from ``repository``
+      - ``shared/apps/<app>/ui.ipynb`` in the sandbox
+    * - Isolation
+      - Strong — separate container and dependencies
+      - Shares the sandbox's Python/system stack (plus an
+        optional packaged kernel)
+    * - Lifecycle
+      - Independent; redeploys on commit change
+      - Tied to the sandbox and its app-manager-built kernel
+
+Docker apps
+-----------
+
+A docker app lives in its own repository and runs in its own container with a
+dedicated ``port``. Because it is fully isolated, the catalog schema requires
+``repository``, ``branch``, and ``commit`` for every ``endpoint: docker`` entry.
+
+When SEPAL launches the app it runs the equivalent of:
+
+.. code-block:: bash
+
+    git fetch origin <branch>
+    git checkout --detach <commit>
+
+That is why the pinned ``commit`` must be reachable from ``branch`` (see
+:ref:`developers_apps_releases`). The app's dependencies are baked into its container, so
+its lifecycle is independent of the rest of the platform — it changes only when
+you bump its commit in the catalog.
+
+Use a docker app when your tool needs strong isolation, its own service, a
+specific port, or a runtime that differs from the SEPAL sandbox.
+
+Jupyter (and shiny, rstudio) apps
+---------------------------------
+
+A jupyter app does not get its own container. Its code is checked out into the
+shared user sandbox under ``shared/apps/<app>/`` and its ``ui.ipynb`` notebook is
+rendered with `Voila <https://voila.readthedocs.io>`__ (hence catalog paths such
+as ``/sandbox/jupyter/voila/render/shared/apps/<app>/ui.ipynb``). It runs against
+the sandbox's Python and system libraries rather than a private container, so it
+does not carry a pinned ``commit`` — its lifecycle follows the sandbox and the
+kernel built for it by the app-manager.
+
+That kernel is where a jupyter app declares the environment it needs. Packaging
+that environment correctly — so it is built once and reused — is the subject of
+:ref:`developers_apps_kernels`.
+
+Use a jupyter app when your tool is a notebook-based UI that fits the SEPAL
+sandbox and benefits from being close to the user's files and the shared
+geospatial stack.
+
+.. graphviz::
+
+    digraph endpoints {
+        rankdir=LR;
+        node [shape=box, fontname="sans-serif"];
+
+        catalog [label="Catalog entry\n(endpoint)"];
+        docker  [label="Docker app\nown container + port\npinned commit"];
+        jupyter [label="Jupyter app\nshared sandbox\nVoila + kernel"];
+
+        catalog -> docker  [label="docker"];
+        catalog -> jupyter [label="jupyter / shiny / rstudio"];
+    }

--- a/docs/source/developers/apps/app_types.rst
+++ b/docs/source/developers/apps/app_types.rst
@@ -87,7 +87,7 @@ geospatial stack.
         node [shape=box, fontname="sans-serif"];
 
         catalog [label="Catalog entry\n(endpoint)"];
-        docker  [label="Docker app\nown container + port\npinned commit"];
+        docker  [label="Docker app\nprivate container + port\npinned commit"];
         jupyter [label="Jupyter app\nshared sandbox\nVoila + kernel"];
 
         catalog -> docker  [label="docker"];

--- a/docs/source/developers/apps/index.rst
+++ b/docs/source/developers/apps/index.rst
@@ -1,0 +1,54 @@
+.. _developers_apps:
+
+Develop apps
+============
+*Build, release and publish your own apps on the SEPAL platform*
+
+These pages explain how SEPAL decides which app code to run and how that code
+reaches the platform — useful when you want to add an app, ship a new version
+of an existing one, or package a reusable environment for a notebook or
+workflow.
+
+.. note::
+
+    The set of apps SEPAL runs is curated in the
+    `dfguerrerom/sepal-apps-catalog <https://github.com/dfguerrerom/sepal-apps-catalog>`__
+    repository. Getting an app onto SEPAL — or updating one — means opening a
+    pull request there. For docker apps, the catalog also pins the *exact
+    commit* SEPAL will run; for jupyter and shiny apps, the catalog records the
+    ``branch`` and SEPAL still runs the tip of that branch. The pages below
+    walk through both flows.
+
+How an app reaches SEPAL
+------------------------
+
+.. graphviz::
+
+    digraph lifecycle {
+        rankdir=LR;
+        node [shape=box, fontname="sans-serif"];
+
+        repo   [label="App source repo\n(your GitHub)"];
+        rel    [label="Release / version", shape=ellipse];
+        pr     [label="Catalog PR\n(apps.test.json)"];
+        ci     [label="CI review\n(validate + risk flags)"];
+        test   [label="test.sepal.io", shape=ellipse];
+        prod   [label="sepal.io", shape=ellipse];
+        kernel [label="Kernel build\n(sepal_environment.yml)", shape=box, style=dashed];
+
+        repo -> rel -> pr -> ci -> test;
+        test -> prod [label="promote PR"];
+        repo -> kernel [label="jupyter apps", style=dashed];
+        kernel -> test [style=dashed];
+    }
+
+Contents
+--------
+
+.. toctree::
+    :maxdepth: 1
+
+    Docker vs. Jupyter apps<app_types>
+    Request a new app<app_catalog>
+    Request a new kernel<kernels>
+    Create a release<releases>

--- a/docs/source/developers/apps/kernels.rst
+++ b/docs/source/developers/apps/kernels.rst
@@ -1,0 +1,141 @@
+.. _developers_apps_kernels:
+
+Request a new kernel
+====================
+*Package an environment once and share it with every SEPAL user as a named Jupyter kernel*
+
+A "kernel" in the SEPAL catalog is really just a special-purpose jupyter app:
+the same catalog entry, the same PR flow, the same release lifecycle. The only
+difference is *intent* — the deliverable is the environment, not a notebook UI.
+If you have read :ref:`developers_apps_catalog`, you already know 90% of how to
+ship one.
+
+Why request a kernel
+--------------------
+
+Some notebooks need a large or unusual environment: a deep-learning stack, a
+pinned GDAL build, a model with awkward native dependencies. Asking every user
+— or every training participant — to build that environment by hand is slow,
+fragile, and easy to get subtly wrong.
+
+A shared kernel solves that. You package the environment once, in a repository;
+SEPAL builds it centrally and exposes it as a named Jupyter kernel that lives
+in the shared sandbox. Every user then simply *selects* that kernel for the
+relevant notebook — no per-user installation, and everyone runs the same,
+reproducible environment.
+
+This is the right approach when:
+
+-   You are preparing a notebook or workflow for a training and want every
+    participant on an identical environment.
+-   A notebook needs heavy dependencies (GPU/ML, large geospatial stacks) that
+    are wasteful to rebuild per user.
+-   You want a stable, named environment that several notebooks can share.
+
+It is *not* the right approach for quick, personal experiments. For an
+environment only you need, build it yourself with :guilabel:`uv` or
+:guilabel:`micromamba` — see :ref:`env_management`.
+
+It's the same flow as a jupyter app
+------------------------------------
+
+A kernel-only entry in the catalog is just a jupyter app that:
+
+-   has ``"hidden": true`` (no dashboard tile — see below), and
+-   ships a ``sepal_environment.yml`` at the root of its repository.
+
+Everything else — the PR against ``apps.test.json``, the validation and
+review-helper workflows, the promotion to ``apps.prod.json`` — works exactly as
+described in :ref:`developers_apps_catalog`.
+
+The one extra behaviour, which fires automatically whenever the app-manager
+updates a jupyter app, is the kernel build itself: if the cloned repository
+contains a ``sepal_environment.yml`` (or a legacy ``requirements.txt``), SEPAL
+builds an isolated environment from it and registers it as a named Jupyter
+kernel. For a ``sepal_environment.yml`` the build is, in essence:
+
+.. code-block:: bash
+
+    micromamba create -y -p <venv_path> -f sepal_environment.yml
+    <venv_path>/bin/pip install ipykernel
+
+The script then writes a ``kernel.json`` so the environment shows up in
+JupyterLab as ``(venv) <app label>``, and wires the geospatial environment
+variables (``PROJ_LIB``, ``PROJ_DATA``, ``GDAL_DATA``) to the environment's own
+data directories. The kernel is rebuilt only when the environment file changes
+(the script compares timestamps against an ``.installed`` marker), so unchanged
+apps don't pay a rebuild cost on every update.
+
+Hiding the app
+--------------
+
+A packaged kernel usually has no dashboard UI of its own — it exists to back
+*other* notebooks. Set ``"hidden": true`` on its catalog entry so SEPAL builds
+the environment and registers the kernel without showing a tile in the apps
+dashboard.
+
+Worked example: ``sepal-sam``
+------------------------------
+
+The catalog entry below is a real, hidden kernel app. Its description is simply
+*"SAM environment"* — it ships the environment for SAM-based notebooks and
+never appears in the dashboard:
+
+.. code-block:: json
+
+    {
+      "hidden": true,
+      "id": "sepal-sam",
+      "label": "Sepal SAM",
+      "endpoint": "jupyter",
+      "repository": "https://github.com/dfguerrerom/sepal-sam",
+      "branch": "main",
+      "description": "SAM environment"
+    }
+
+Because the ``sepal-sam`` repository contains a ``sepal_environment.yml``,
+SEPAL builds its micromamba environment and registers a ``(venv) Sepal SAM``
+kernel. Any notebook a user opens can then select that kernel and run against
+the SAM stack immediately.
+
+.. _developers_apps_kernels_envfile:
+
+Recommended: ``sepal_environment.yml``
+--------------------------------------
+
+Declare your kernel with a ``sepal_environment.yml`` at the root of the app
+repository. It is a standard conda/micromamba environment file, and it is the
+preferred way to define a SEPAL kernel because micromamba bundles native
+libraries (GDAL, GEOS, CUDA, HDF5, …) inside the environment — so it keeps
+working when SEPAL upgrades system-level libraries. A plain ``requirements.txt``
+is still supported for backward compatibility, but it installs into a
+system-Python venv and can break on platform upgrades.
+
+A minimal example:
+
+.. code-block:: yaml
+
+    name: sepal-sam
+    channels:
+      - conda-forge
+    dependencies:
+      - python=3.12
+      - gdal
+      - rasterio
+      - pip:
+        - segment-geospatial
+
+.. tip::
+
+    You do not need to add ``ipykernel`` yourself — SEPAL installs it into the
+    environment when it builds the kernel.
+
+Once the file is in your repository and the app is in the catalog (see
+:ref:`developers_apps_catalog`), every release that changes
+``sepal_environment.yml`` triggers a rebuild of the shared kernel on the next
+update.
+
+.. seealso::
+
+    :ref:`env_management` — managing your *own* environments and kernels
+    interactively, when you don't need a shared, centrally built one.

--- a/docs/source/developers/apps/releases.rst
+++ b/docs/source/developers/apps/releases.rst
@@ -1,0 +1,152 @@
+.. _developers_apps_releases:
+
+Create a release
+================
+*Ship a new version of an app already in the SEPAL catalog*
+
+Once your app is in the catalog (see :ref:`developers_apps_catalog`), the way
+you ship a new version depends on the app's ``endpoint`` (see
+:ref:`developers_apps_types`). Docker apps and jupyter/shiny apps (including
+kernels) use different release mechanisms:
+
+-   **Jupyter and Shiny apps** (and :ref:`kernels <developers_apps_kernels>`,
+    which are just hidden jupyter apps) are not pinned to a commit. The
+    app-manager checks out the tip of the catalog's ``branch`` (defaulting to
+    ``HEAD``) every time the sandbox refreshes the app, so a release is just a
+    push to that branch in your source repository — no catalog change is
+    needed.
+-   **Docker apps** are pinned in the catalog to an exact commit SHA. SEPAL
+    keeps running the old commit until that ``commit`` field is advanced, so a
+    release is, in practice, a pull request against the catalog.
+
+The rest of this page describes each flow in turn.
+
+.. _developers_apps_releases_jupyter:
+
+Jupyter, Shiny and kernel apps
+------------------------------
+
+These endpoints don't take a ``commit`` field in the catalog — only
+``branch`` (which defaults to ``HEAD``). On every sandbox refresh the
+app-manager runs the equivalent of ``git fetch`` + checkout of that branch's
+tip, so whatever is at the head of the tracked branch is what users get.
+
+Releasing a new version
+~~~~~~~~~~~~~~~~~~~~~~~
+
+Push the change to the branch the catalog tracks for your app. The next time
+the user's sandbox refreshes the app, the new tip is picked up automatically.
+No catalog PR is required.
+
+The release branch convention
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Because every push to the tracked branch is effectively a release, most
+contributors keep a dedicated ``release`` branch and pin ``"branch":
+"release"`` in the catalog rather than ``main``. You develop on ``main`` and
+merge into ``release`` only when you intend to publish — that way unreviewed
+work on ``main`` doesn't go live the moment it is pushed.
+
+This is a convention, not a requirement. Any branch works; if you pin
+``main``, every push to ``main`` is a release.
+
+.. _developers_apps_releases_docker:
+
+Docker apps
+-----------
+
+Docker apps carry a required ``commit`` SHA in the catalog. The app-launcher
+runs ``git fetch origin <branch>`` followed by
+``git checkout --detach <commit>``, so SEPAL only ever runs that exact commit
+— regardless of what is at the tip of ``branch``. Shipping a new version
+therefore means advancing the ``commit`` field in the catalog.
+
+There are two ways to do that: a manual pull request, or an automated bump
+triggered when your source repository publishes a release.
+
+The release branch convention
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Many docker apps pin ``"branch": "release"`` rather than ``main``. Since the
+catalog validation requires the pinned ``commit`` to be reachable from
+``branch``, keeping a dedicated ``release`` branch lets you continue
+developing on ``main`` while controlling exactly which commits are eligible to
+be pinned: you merge into ``release`` only when you intend to publish, and
+that merge commit is the one you pin.
+
+This is a convention, not a requirement — any branch works as long as the
+pinned commit is reachable from it.
+
+Manual release
+~~~~~~~~~~~~~~
+
+#.  Push the code you want to ship and note the commit SHA on your release
+    branch.
+#.  Open a PR against ``apps.test.json`` changing the ``commit`` field of your
+    app's entry (and ``branch`` if it moved).
+#.  The ``Review helper`` bot posts a compare link showing exactly what changed
+    upstream between the old and new commit, with risk flags. A maintainer
+    reviews and merges; the change goes live on test.sepal.io.
+#.  Promote to sepal.io with a second PR against ``apps.prod.json`` (or the
+    ``Promote app to production`` workflow).
+
+.. tip::
+
+    Validation requires the new commit to be an *ancestor of* (or equal to) the
+    branch tip — exactly what the app-launcher needs, since it runs
+    ``git fetch origin <branch>`` then ``git checkout --detach <commit>``. You
+    can spot-check this before opening the PR:
+
+    .. code-block:: bash
+
+        gh api repos/<owner>/<repo>/compare/<branch>...<commit> --jq '.ahead_by'
+        # must print 0
+
+Automated release from your source repo
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The catalog can bump a docker app automatically when your repository publishes
+a GitHub release. The catalog's ``update-from-release.yml`` workflow listens
+for a ``repository_dispatch`` event of type ``bump-app``; on receipt it
+updates the app's ``commit`` in ``apps.test.json`` and opens a pull request
+for a maintainer to review.
+
+To wire this up, add a workflow to your app's repository that sends the
+dispatch on release. The snippet below is a starting point — adjust the app
+``id`` and the catalog repository to match your setup:
+
+.. code-block:: yaml
+
+    # .github/workflows/notify-sepal-catalog.yml in your app repo
+    name: Notify SEPAL catalog
+    on:
+      release:
+        types: [published]
+
+    jobs:
+      bump:
+        runs-on: ubuntu-latest
+        steps:
+          - name: Dispatch bump-app to the catalog
+            run: |
+              gh api repos/dfguerrerom/sepal-apps-catalog/dispatches \
+                -f event_type=bump-app \
+                -F client_payload[id]="my-app" \
+                -F client_payload[commit]="${GITHUB_SHA}"
+            env:
+              GH_TOKEN: ${{ secrets.SEPAL_CATALOG_DISPATCH_TOKEN }}
+
+The token must have permission to dispatch to the catalog repository. The bump
+only updates ``commit`` — never ``branch`` — and still goes through the normal
+validation, risk-flag review, and maintainer merge before reaching test.
+
+.. note::
+
+    The exact ``client_payload`` fields the catalog expects may evolve. Confirm
+    against the catalog's ``update-from-release.yml`` and ``docs/ci.md`` before
+    relying on this in production.
+
+.. seealso::
+
+    The end-to-end lifecycle diagram lives on the section landing page —
+    :ref:`developers_apps`.

--- a/docs/source/developers/index.rst
+++ b/docs/source/developers/index.rst
@@ -1,0 +1,15 @@
+.. _developers:
+
+For developers
+==============
+*Tools, conventions and workflows for building on the SEPAL platform*
+
+This section is for developers and trainers working on SEPAL rather than just
+using it: scripting against the sandbox from the command line, packaging
+environments for shared use, and publishing apps that other users can run.
+
+.. toctree::
+    :maxdepth: 2
+
+    Command-line tools<../cli/index>
+    Develop apps<apps/index>

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -24,10 +24,10 @@ Documentation
    Getting started<setup/index>
    Cookbook<cookbook/index>
    Modules<modules/index>
-   CLI<cli/index>
    Workflows<workflows/index>
    Features<feature/index>
    Troubleshooting<troubleshooting/index>
+   Developers<developers/index>
     <team/index>
 
 .. line-break::


### PR DESCRIPTION
Introduces a new top-level **For developers** section that consolidates developer-facing documentation. It groups the existing CLI pages with a new **Develop apps** track explaining the `sepal-apps-catalog` workflow.

## New pages

- **Docker vs. Jupyter apps** — endpoints, isolation, versioning, lifecycle.
- **Request a new app** — catalog anatomy (identification + routing, docker-only fields, presentation, behaviour flags), the PR flow against `apps.test.json`, and promotion to `apps.prod.json`.
- **Request a new kernel** — packaging a shared environment as a hidden jupyter app via `sepal_environment.yml`, with `sepal-sam` as the worked example.
- **Create a release** — manual SHA bump (docker) and the `bump-app` `repository_dispatch` flow from a source repo.

## Structure

A new umbrella page `developers/index.rst` pulls in `cli/index` and the new `developers/apps/index`. The CLI pages stay at their existing paths (`cli/*.html`) so all public URLs keep working — only navigation changes.

```
docs/source/
  developers/
    index.rst                      # umbrella (toctree -> cli + apps)
    apps/
      index.rst                    # landing + lifecycle graphviz
      app_types.rst                # docker vs jupyter (1st, foundational)
      app_catalog.rst              # request a new app
      kernels.rst                  # request a new kernel
      releases.rst                 # create a release
```

The top-level toctree in `index.rst` swaps the old `CLI` entry for the new `Developers` umbrella.

## Linked catalog issues

Writing the docs surfaced two gaps in the catalog repo; tracking issues filed:

- dfguerrerom/sepal-apps-catalog#40 — allow contributors to promote their own apps from test to prod.
- dfguerrerom/sepal-apps-catalog#41 — validate that docker ports are unique and assigned incrementally.

## Verification

`nox -s docs` passes with zero warnings; `check_warnings.py` is green.